### PR TITLE
Changed the condition in the checkBody() middleware

### DIFF
--- a/4-natours/after-section-06/controllers/tourController.js
+++ b/4-natours/after-section-06/controllers/tourController.js
@@ -17,7 +17,7 @@ exports.checkID = (req, res, next, val) => {
 };
 
 exports.checkBody = (req, res, next) => {
-  if (!req.body.name || !req.body.price) {
+  if (!("name" in req.body) || !("price" in req.body) {
     return res.status(400).json({
       status: 'fail',
       message: 'Missing name or price'


### PR DESCRIPTION
req.body.name would return undefined not only when the name property is not inside the req.body object, but also when it exists, but it's value is 'undefined'. Thus, a better way to check whether a key is there in the object would be to use the 'in' keyword